### PR TITLE
Allow configuration of the "session locked" screen delay

### DIFF
--- a/README
+++ b/README
@@ -16,14 +16,16 @@ Usage
 =====
 
 After installing light-locker, it will auto start along your session and you will be able to lock your session with "light-locker-command -l".
-This will redirect you to VT8 (assuming that your open session was on VT7 and is now kept safe by light-locker) and present LightDM's greeter for unlocking your session again.
+This will redirect you to VT8 (assuming that your open session was on VT7 and is now kept safe by light-locker) and presents LightDM's greeter for unlocking your session.
 On suspend/resume light-locker will lock the active session and redirect to the LightDM's greeter for unlocking the session again.
 There is no support for gnome-settings-daemon in order to keep things slim, so you might have to add a custom keyboard-shortcut for this to work.
 light-locker will automatically lock the session shortly after the X11 screen saver kicks in. The timeout can be set with --lock-after-screensaver. With xset the X11 screen saver can be adjusted.
 Use --late-locking to avoid some of the negative effects of VT switching. This will lock the session on the deactivation of X11 screen saver instead of activation.
 light-locker will automatically lock the session on suspend/resume. To disable this behaviour with --no-lock-on-suspend.
-With --lock-on-lid light-locker will automatically lock the lid close.
+With --lock-on-lid light-locker will automatically lock on lid close.
 With logind sessions can have an idle hint. This is used to perform some action after a timeout. Use --idle-hint to let light-locker set the idle hint, in case nothing else does.
+If you manually switch VTs (eg. with Ctrl + Alt + F7). A message will be displayed in the locked session and you will be redirecteed to the greeter automatically.
+The time this message is shown can be set with --locked-message.
 
 
 Building

--- a/data/apps.light-locker.gschema.xml.in.in
+++ b/data/apps.light-locker.gschema.xml.in.in
@@ -37,5 +37,14 @@
       </description>
     </key>
 
+    <key name="locked-message" type="u">
+      <range min="0" max="30" />
+      <default>10</default>
+      <summary>Seconds locked message is shown</summary>
+      <description>Switch to the greeter after this mumber of seconds. Durings
+      this time the session is locked message is shown. This time gives the
+      user time to read the message and understand what is going on.</description>
+    </key>
+
   </schema>
 </schemalist>

--- a/data/light-locker.1
+++ b/data/light-locker.1
@@ -57,6 +57,9 @@ Set the session idle hint while the screenaver is active
 .TP
 .B \-\-no\-idle\-hint
 Don't set the idle hint. Let something else handle that
+.TP
+.BI \-\-locked\-message\fR=\fIS
+Wait S seconds on session-locked screen
 .P
 This program also accepts the standard GTK options.
 .SH SEE ALSO

--- a/src/gs-manager.c
+++ b/src/gs-manager.c
@@ -44,6 +44,7 @@ struct GSManagerPrivate
 
         /* Configuration */
         guint        lock_after;
+        guint        lock_wait;
 
         /* State */
         guint        active : 1;
@@ -174,6 +175,7 @@ gs_manager_init (GSManager *manager)
         manager->priv->visible = TRUE;
 
         manager->priv->lock_after = 5;
+        manager->priv->lock_wait = 10;
 }
 
 
@@ -442,9 +444,9 @@ gs_manager_timed_switch (GSManager *manager)
                 return;
         }
 
-        gs_debug ("Start switch to greeter timer");
+        gs_debug ("Switch to greeter in %u seconds", manager->priv->lock_wait);
 
-        manager->priv->greeter_timeout_id = g_timeout_add_seconds (10,
+        manager->priv->greeter_timeout_id = g_timeout_add_seconds (manager->priv->lock_wait,
                                                                    (GSourceFunc)switch_greeter_timeout,
                                                                    manager);
 }
@@ -753,6 +755,14 @@ gs_manager_set_lock_after (GSManager *manager,
 {
         manager->priv->lock_after = lock_after;
 }
+
+void
+gs_manager_set_lock_wait (GSManager *manager,
+                          guint      lock_wait)
+{
+        manager->priv->lock_wait = lock_wait;
+}
+
 
 void
 gs_manager_show_content (GSManager *manager)

--- a/src/gs-manager.h
+++ b/src/gs-manager.h
@@ -74,6 +74,9 @@ void        gs_manager_set_lid_closed       (GSManager *manager,
 void        gs_manager_set_lock_after       (GSManager  *manager,
                                              guint       lock_after);
 
+void        gs_manager_set_lock_wait        (GSManager  *manager,
+                                             guint       lock_wait);
+
 void        gs_manager_show_content         (GSManager  *manager);
 
 G_END_DECLS

--- a/src/gs-manager.h
+++ b/src/gs-manager.h
@@ -74,7 +74,7 @@ void        gs_manager_set_lid_closed       (GSManager *manager,
 void        gs_manager_set_lock_after       (GSManager  *manager,
                                              guint       lock_after);
 
-void        gs_manager_set_lock_wait        (GSManager  *manager,
+void        gs_manager_set_switch_time      (GSManager  *manager,
                                              guint       lock_wait);
 
 void        gs_manager_show_content         (GSManager  *manager);

--- a/src/gs-monitor.c
+++ b/src/gs-monitor.c
@@ -57,6 +57,7 @@ struct GSMonitorPrivate
         guint            idle_hint : 1;
         guint            perform_lock : 1;
         guint            lock_on_lid : 1;
+        guint            lock_wait;
 };
 
 G_DEFINE_TYPE (GSMonitor, gs_monitor, G_TYPE_OBJECT)
@@ -206,6 +207,20 @@ conf_lock_after_screensaver_cb (LLConfig    *conf,
 }
 
 static void
+conf_lock_wait_cb (LLConfig    *conf,
+                                GParamSpec  *pspec,
+                                GSMonitor   *monitor)
+{
+        guint lock_wait = 10;
+
+        g_object_get (G_OBJECT(conf),
+                      "lock-wait", &lock_wait,
+                      NULL);
+
+        gs_manager_set_lock_wait (monitor->priv->manager, lock_wait);
+}
+
+static void
 conf_lock_on_lid_cb (LLConfig    *conf,
                      GParamSpec  *pspec,
                      GSMonitor   *monitor)
@@ -244,6 +259,7 @@ disconnect_conf_signals (GSMonitor *monitor)
         g_signal_handlers_disconnect_by_func (monitor->priv->conf, conf_lock_after_screensaver_cb, monitor);
         g_signal_handlers_disconnect_by_func (monitor->priv->conf, conf_lock_on_lid_cb, monitor);
         g_signal_handlers_disconnect_by_func (monitor->priv->conf, conf_idle_hint_cb, monitor);
+        g_signal_handlers_disconnect_by_func (monitor->priv->conf, conf_lock_wait_cb, monitor);
 }
 
 static void
@@ -259,6 +275,8 @@ connect_conf_signals (GSMonitor *monitor)
                           G_CALLBACK (conf_lock_on_lid_cb), monitor);
         g_signal_connect (monitor->priv->conf, "notify::idle-hint",
                           G_CALLBACK (conf_idle_hint_cb), monitor);
+        g_signal_connect (monitor->priv->conf, "notify::lock-wait",
+                          G_CALLBACK (conf_lock_wait_cb), monitor);
 }
 
 static void
@@ -589,6 +607,7 @@ gs_monitor_new (LLConfig *config)
         gboolean lock_on_suspend = FALSE;
         gboolean lock_on_lid = FALSE;
         guint lock_after_screensaver = 5;
+        guint lock_wait = 10;
         gboolean idle_hint = FALSE;
 
         monitor = g_object_new (GS_TYPE_MONITOR, NULL);
@@ -603,14 +622,17 @@ gs_monitor_new (LLConfig *config)
                       "lock-on-lid", &lock_on_lid,
                       "lock-after-screensaver", &lock_after_screensaver,
                       "idle-hint", &idle_hint,
+                      "lock-wait", &lock_wait,
                       NULL);
 
         monitor->priv->late_locking = late_locking;
         monitor->priv->lock_on_suspend = lock_on_suspend;
         monitor->priv->lock_on_lid = lock_on_lid;
         monitor->priv->idle_hint = idle_hint;
+        monitor->priv->lock_wait = lock_wait;
 
         gs_manager_set_lock_after (monitor->priv->manager, lock_after_screensaver);
+        gs_manager_set_lock_wait (monitor->priv->manager, lock_wait);
 
         if (lock_on_suspend) {
               gs_listener_delay_suspend (monitor->priv->listener);

--- a/src/gs-monitor.c
+++ b/src/gs-monitor.c
@@ -216,7 +216,7 @@ conf_locked_message_cb (LLConfig    *conf,
                       "locked-message", &locked_message,
                       NULL);
 
-        gs_manager_set_lock_wait (monitor->priv->manager, locked_message);
+        gs_manager_set_switch_time (monitor->priv->manager, locked_message);
 }
 
 static void
@@ -421,6 +421,8 @@ listener_lid_closed_cb (GSListener *listener,
 {
         gboolean closed = gs_listener_is_lid_closed (listener);
 
+        gs_manager_set_lid_closed (monitor->priv->manager, closed);
+
         /* If the manager requested a lock when the lid was closed.
          * We don't take the reason of the lock into account.
          * That would only complicate it.
@@ -438,8 +440,6 @@ listener_lid_closed_cb (GSListener *listener,
                 monitor->priv->perform_lock = FALSE;
                 return;
         }
-
-        gs_manager_set_lid_closed (monitor->priv->manager, closed);
 
         if (! monitor->priv->lock_on_lid)
                 return;
@@ -630,7 +630,7 @@ gs_monitor_new (LLConfig *config)
         monitor->priv->idle_hint = idle_hint;
 
         gs_manager_set_lock_after (monitor->priv->manager, lock_after_screensaver);
-        gs_manager_set_lock_wait (monitor->priv->manager, locked_message);
+        gs_manager_set_switch_time (monitor->priv->manager, locked_message);
 
         if (lock_on_suspend) {
               gs_listener_delay_suspend (monitor->priv->listener);

--- a/src/gs-monitor.c
+++ b/src/gs-monitor.c
@@ -57,7 +57,6 @@ struct GSMonitorPrivate
         guint            idle_hint : 1;
         guint            perform_lock : 1;
         guint            lock_on_lid : 1;
-        guint            lock_wait;
 };
 
 G_DEFINE_TYPE (GSMonitor, gs_monitor, G_TYPE_OBJECT)
@@ -207,17 +206,17 @@ conf_lock_after_screensaver_cb (LLConfig    *conf,
 }
 
 static void
-conf_lock_wait_cb (LLConfig    *conf,
+conf_locked_message_cb (LLConfig    *conf,
                                 GParamSpec  *pspec,
                                 GSMonitor   *monitor)
 {
-        guint lock_wait = 10;
+        guint locked_message = 10;
 
         g_object_get (G_OBJECT(conf),
-                      "lock-wait", &lock_wait,
+                      "locked-message", &locked_message,
                       NULL);
 
-        gs_manager_set_lock_wait (monitor->priv->manager, lock_wait);
+        gs_manager_set_lock_wait (monitor->priv->manager, locked_message);
 }
 
 static void
@@ -259,7 +258,7 @@ disconnect_conf_signals (GSMonitor *monitor)
         g_signal_handlers_disconnect_by_func (monitor->priv->conf, conf_lock_after_screensaver_cb, monitor);
         g_signal_handlers_disconnect_by_func (monitor->priv->conf, conf_lock_on_lid_cb, monitor);
         g_signal_handlers_disconnect_by_func (monitor->priv->conf, conf_idle_hint_cb, monitor);
-        g_signal_handlers_disconnect_by_func (monitor->priv->conf, conf_lock_wait_cb, monitor);
+        g_signal_handlers_disconnect_by_func (monitor->priv->conf, conf_locked_message_cb, monitor);
 }
 
 static void
@@ -276,7 +275,7 @@ connect_conf_signals (GSMonitor *monitor)
         g_signal_connect (monitor->priv->conf, "notify::idle-hint",
                           G_CALLBACK (conf_idle_hint_cb), monitor);
         g_signal_connect (monitor->priv->conf, "notify::lock-wait",
-                          G_CALLBACK (conf_lock_wait_cb), monitor);
+                          G_CALLBACK (conf_locked_message_cb), monitor);
 }
 
 static void
@@ -607,7 +606,7 @@ gs_monitor_new (LLConfig *config)
         gboolean lock_on_suspend = FALSE;
         gboolean lock_on_lid = FALSE;
         guint lock_after_screensaver = 5;
-        guint lock_wait = 10;
+        guint locked_message = 10;
         gboolean idle_hint = FALSE;
 
         monitor = g_object_new (GS_TYPE_MONITOR, NULL);
@@ -622,17 +621,16 @@ gs_monitor_new (LLConfig *config)
                       "lock-on-lid", &lock_on_lid,
                       "lock-after-screensaver", &lock_after_screensaver,
                       "idle-hint", &idle_hint,
-                      "lock-wait", &lock_wait,
+                      "locked-message", &locked_message,
                       NULL);
 
         monitor->priv->late_locking = late_locking;
         monitor->priv->lock_on_suspend = lock_on_suspend;
         monitor->priv->lock_on_lid = lock_on_lid;
         monitor->priv->idle_hint = idle_hint;
-        monitor->priv->lock_wait = lock_wait;
 
         gs_manager_set_lock_after (monitor->priv->manager, lock_after_screensaver);
-        gs_manager_set_lock_wait (monitor->priv->manager, lock_wait);
+        gs_manager_set_lock_wait (monitor->priv->manager, locked_message);
 
         if (lock_on_suspend) {
               gs_listener_delay_suspend (monitor->priv->listener);

--- a/src/light-locker.c
+++ b/src/light-locker.c
@@ -55,7 +55,7 @@ main (int    argc,
 
         LLConfig           *conf;
         static gint         lock_after_screensaver;
-        static gint         lock_wait;
+        static gint         locked_message;
         static gboolean     late_locking;
         static gboolean     lock_on_suspend;
         static gboolean     lock_on_lid;
@@ -81,7 +81,7 @@ main (int    argc,
 #endif
                 { "idle-hint", 0, 0, G_OPTION_ARG_NONE, &idle_hint, N_("Set idle hint during screensaver"), NULL },
                 { "no-idle-hint", 0, G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE, &idle_hint, N_("Let something else handle the idle hint"), NULL },
-                { "wait", 0, 0, G_OPTION_ARG_INT, &lock_wait, N_("Wait S seconds on session-locked screen"), "S" },
+                { "locked-message", 0, 0, G_OPTION_ARG_INT, &locked_message, N_("Wait S seconds on session-locked screen"), "S" },
                 { NULL }
         };
 
@@ -102,7 +102,7 @@ main (int    argc,
                       "lock-after-screensaver", &lock_after_screensaver,
                       "lock-on-lid", &lock_on_lid,
                       "idle-hint", &idle_hint,
-                      "lock-wait", &lock_wait,
+                      "locked-message", &locked_message,
                       NULL);
 
 #ifndef WITH_LATE_LOCKING
@@ -135,8 +135,8 @@ main (int    argc,
         /* Constrain durations */
         if (lock_after_screensaver < 0)
           lock_after_screensaver = 0;
-        if (lock_wait < 2)
-          lock_wait = 2;
+        if (locked_message < 0)
+          locked_message = 0;
 
         /* Update values in LightLockerConf. */
         g_object_set (G_OBJECT(conf),
@@ -145,7 +145,7 @@ main (int    argc,
                       "lock-after-screensaver", lock_after_screensaver,
                       "lock-on-lid", lock_on_lid,
                       "idle-hint", idle_hint,
-                      "lock-wait", lock_wait,
+                      "locked-message", locked_message,
                       NULL);
 
         gs_debug_init (debug, FALSE);
@@ -156,7 +156,7 @@ main (int    argc,
         gs_debug ("lock on suspend %d", lock_on_suspend);
         gs_debug ("lock on lid %d", lock_on_lid);
         gs_debug ("idle hint %d", idle_hint);
-        gs_debug ("lock wait %d", lock_wait);
+        gs_debug ("locked message %d", locked_message);
 
         monitor = gs_monitor_new (conf);
 

--- a/src/light-locker.c
+++ b/src/light-locker.c
@@ -55,6 +55,7 @@ main (int    argc,
 
         LLConfig           *conf;
         static gint         lock_after_screensaver;
+        static gint         lock_wait;
         static gboolean     late_locking;
         static gboolean     lock_on_suspend;
         static gboolean     lock_on_lid;
@@ -80,6 +81,7 @@ main (int    argc,
 #endif
                 { "idle-hint", 0, 0, G_OPTION_ARG_NONE, &idle_hint, N_("Set idle hint during screensaver"), NULL },
                 { "no-idle-hint", 0, G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE, &idle_hint, N_("Let something else handle the idle hint"), NULL },
+                { "wait", 0, 0, G_OPTION_ARG_INT, &lock_wait, N_("Wait S seconds on session-locked screen"), "S" },
                 { NULL }
         };
 
@@ -100,6 +102,7 @@ main (int    argc,
                       "lock-after-screensaver", &lock_after_screensaver,
                       "lock-on-lid", &lock_on_lid,
                       "idle-hint", &idle_hint,
+                      "lock-wait", &lock_wait,
                       NULL);
 
 #ifndef WITH_LATE_LOCKING
@@ -129,6 +132,12 @@ main (int    argc,
                 exit (1);
         }
 
+        /* Constrain durations */
+        if (lock_after_screensaver < 0)
+          lock_after_screensaver = 0;
+        if (lock_wait < 2)
+          lock_wait = 2;
+
         /* Update values in LightLockerConf. */
         g_object_set (G_OBJECT(conf),
                       "lock-on-suspend", lock_on_suspend,
@@ -136,6 +145,7 @@ main (int    argc,
                       "lock-after-screensaver", lock_after_screensaver,
                       "lock-on-lid", lock_on_lid,
                       "idle-hint", idle_hint,
+                      "lock-wait", lock_wait,
                       NULL);
 
         gs_debug_init (debug, FALSE);
@@ -146,6 +156,7 @@ main (int    argc,
         gs_debug ("lock on suspend %d", lock_on_suspend);
         gs_debug ("lock on lid %d", lock_on_lid);
         gs_debug ("idle hint %d", idle_hint);
+        gs_debug ("lock wait %d", lock_wait);
 
         monitor = gs_monitor_new (conf);
 

--- a/src/ll-config.c
+++ b/src/ll-config.c
@@ -19,6 +19,7 @@ enum
     PROP_LOCK_AFTER_SCREENSAVER,
     PROP_LOCK_ON_LID,
     PROP_IDLE_HINT,
+    PROP_LOCK_WAIT,
     N_PROP
 };
 
@@ -47,6 +48,7 @@ struct _LLConfig
     gboolean   lock_on_suspend : 1;
     gboolean   lock_on_lid : 1;
     gboolean   idle_hint : 1;
+    guint      lock_wait;
 };
 
 G_DEFINE_TYPE (LLConfig, ll_config, G_TYPE_OBJECT)
@@ -88,6 +90,10 @@ static void ll_config_set_property (GObject      *object,
 
         case PROP_IDLE_HINT:
             conf->idle_hint = g_value_get_boolean(value);
+            break;
+
+        case PROP_LOCK_WAIT:
+            conf->lock_wait = g_value_get_uint(value);
             break;
 
         default:
@@ -132,6 +138,10 @@ static void ll_config_get_property (GObject    *object,
 
         case PROP_IDLE_HINT:
             g_value_set_boolean(value, conf->idle_hint);
+            break;
+
+        case PROP_LOCK_WAIT:
+            g_value_set_uint(value, conf->lock_wait);
             break;
 
         default:
@@ -220,6 +230,22 @@ ll_config_class_init (LLConfigClass *klass)
                                                            NULL,
                                                            FALSE,
                                                            G_PARAM_READWRITE));
+
+    /**
+     * LLConfig:lock-wait:
+     *
+     * Seconds to force user to wait while displaying the "session locked" screen
+     **/
+    g_object_class_install_property (object_class,
+                                     PROP_LOCK_WAIT,
+                                     g_param_spec_uint ("lock-wait",
+                                                        NULL,
+                                                        NULL,
+                                                        0,
+                                                        10,
+                                                        0,
+                                                        G_PARAM_READWRITE));
+
 }
 
 /**
@@ -239,6 +265,7 @@ ll_config_init (LLConfig *conf)
 #endif
 
     conf->lock_after_screensaver = 5;
+    conf->lock_wait = 10;
 #ifdef WITH_LATE_LOCKING
     conf->late_locking = WITH_LATE_LOCKING;
 #endif

--- a/src/ll-config.c
+++ b/src/ll-config.c
@@ -19,7 +19,7 @@ enum
     PROP_LOCK_AFTER_SCREENSAVER,
     PROP_LOCK_ON_LID,
     PROP_IDLE_HINT,
-    PROP_LOCK_WAIT,
+    PROP_LOCKED_MESSAGE,
     N_PROP
 };
 
@@ -48,7 +48,7 @@ struct _LLConfig
     gboolean   lock_on_suspend : 1;
     gboolean   lock_on_lid : 1;
     gboolean   idle_hint : 1;
-    guint      lock_wait;
+    guint      locked_message;
 };
 
 G_DEFINE_TYPE (LLConfig, ll_config, G_TYPE_OBJECT)
@@ -92,8 +92,8 @@ static void ll_config_set_property (GObject      *object,
             conf->idle_hint = g_value_get_boolean(value);
             break;
 
-        case PROP_LOCK_WAIT:
-            conf->lock_wait = g_value_get_uint(value);
+        case PROP_LOCKED_MESSAGE:
+            conf->locked_message = g_value_get_uint(value);
             break;
 
         default:
@@ -140,8 +140,8 @@ static void ll_config_get_property (GObject    *object,
             g_value_set_boolean(value, conf->idle_hint);
             break;
 
-        case PROP_LOCK_WAIT:
-            g_value_set_uint(value, conf->lock_wait);
+        case PROP_LOCKED_MESSAGE:
+            g_value_set_uint(value, conf->locked_message);
             break;
 
         default:
@@ -232,18 +232,18 @@ ll_config_class_init (LLConfigClass *klass)
                                                            G_PARAM_READWRITE));
 
     /**
-     * LLConfig:lock-wait:
+     * LLConfig:locked-message:
      *
-     * Seconds to force user to wait while displaying the "session locked" screen
+     * Seconds locked message is shown
      **/
     g_object_class_install_property (object_class,
-                                     PROP_LOCK_WAIT,
-                                     g_param_spec_uint ("lock-wait",
+                                     PROP_LOCKED_MESSAGE,
+                                     g_param_spec_uint ("locked-message",
                                                         NULL,
                                                         NULL,
                                                         0,
+                                                        30,
                                                         10,
-                                                        0,
                                                         G_PARAM_READWRITE));
 
 }
@@ -265,7 +265,7 @@ ll_config_init (LLConfig *conf)
 #endif
 
     conf->lock_after_screensaver = 5;
-    conf->lock_wait = 10;
+    conf->locked_message = 10;
 #ifdef WITH_LATE_LOCKING
     conf->late_locking = WITH_LATE_LOCKING;
 #endif


### PR DESCRIPTION
On our family desktop, multiple sessions remain open.
We use <alt><ctrl><F7...12> to switch users quickly many takes during the day.
The resulting hard coded 10 second delay light-locker enforces is annoying.
This patch makes allows that delay to be configured for any number of seconds
down to a minimum of 2.  The default is 10.
I've tried to implement this analogously to "lock-after-screensaver"

Tested on Debian unstable.
