### PR TITLE
Add elogind support

### DIFF
--- a/configure.ac.in
+++ b/configure.ac.in
@@ -448,6 +448,43 @@ AC_SUBST(SYSTEMD_CFLAGS)
 AC_SUBST(SYSTEMD_LIBS)
 
 dnl ---------------------------------------------------------------------------
+dnl elogind
+dnl ---------------------------------------------------------------------------
+
+AC_ARG_WITH(elogind,
+            AS_HELP_STRING([--with-elogind],
+                           [Add elogind support]),
+            [with_elogind=$withval], [with_elogind=auto])
+
+if test "x$with_systemd" = "xyes" && test "x$with_elogind" = "xyes"; then
+    AC_MSG_ERROR([Conflicting options: --with-systemd and --with-elogind])
+fi
+
+PKG_CHECK_MODULES(ELOGIND,
+                  [libelogind],
+                  [have_elogind=yes], [have_elogind=no])
+
+if test "x$with_elogind" = "xauto" ; then
+        if test x$have_elogind = xno ; then
+                use_elogind=no
+        else
+                use_elogind=yes
+        fi
+else
+	use_elogind=$with_elogind
+fi
+
+if test "x$use_elogind" = "xyes"; then
+        if test "x$have_elogind" = "xno"; then
+                AC_MSG_ERROR([Elogind support explicitly required, but elogind not found])
+        fi
+
+        AC_DEFINE(WITH_ELOGIND, 1, [elogind support])
+fi
+AC_SUBST(ELOGIND_CFLAGS)
+AC_SUBST(ELOGIND_LIBS)
+
+dnl ---------------------------------------------------------------------------
 dnl UPower
 dnl ---------------------------------------------------------------------------
 


### PR DESCRIPTION
This patch adds a --with-elogind option (that conflicts with --with-systemd) that enables to build with elogind (systemd-logind in a separate) package. Maybe this helps to resolve #103 