### PR TITLE
Adding support for elogind's standalone logind daemon.

### DIFF
--- a/README
+++ b/README
@@ -34,6 +34,7 @@ Most of these configurations will be enabled automatically when their dependenci
 Here is a list of the different dependencies and there configuration flags:
   --with-gtk2: This decides between the Gtk+-3.0 and Gtk+-2.0 dependency.
   --with-systemd: This adds the support for systemd logind. This option requires the development files to be installed.
+  --with-elogind: This adds support for elogind, a standalone version of systemd's logind daemon. Requires the elogind development files be installed. This option cannot be enabled at the same time as the --with-systemd option above.
   --with-console-kit: This adds the support for ConsoleKit.
   --with-upower: This adds the support for UPower.
   --with-mit-ext: This enables the lock-after-screensaver feature. This options requires the X11 Screen Saver extension development files to be installed.

--- a/configure.ac.in
+++ b/configure.ac.in
@@ -448,6 +448,42 @@ AC_SUBST(SYSTEMD_CFLAGS)
 AC_SUBST(SYSTEMD_LIBS)
 
 dnl ---------------------------------------------------------------------------
+dnl elogind
+dnl ---------------------------------------------------------------------------
+
+AC_ARG_WITH(elogind,
+            AS_HELP_STRING([--with-elogind],
+                           [Add elogind support]),
+            [with_elogind=$withval], [with_elogind=auto])
+
+if test "x$with_systemd" = "xyes" && test "x$with_elogind" = "xyes"; then
+    AC_MSG_ERROR([Conflicting options: --with-systemd and --with-elogind])
+fi
+
+PKG_CHECK_MODULES(ELOGIND,
+                  [libelogind],
+                  [have_elogind=yes], [have_elogind=no])
+
+if test "x$with_elogind" = "xauto" ; then
+        if test x$have_elogind = xno ; then
+                use_elogind=no
+        else
+                use_elogind=yes
+        fi
+else
+	use_elogind=$with_elogind
+fi
+
+if test "x$use_elogind" = "xyes"; then
+        if test "x$have_elogind" = "xno"; then
+                AC_MSG_ERROR([Elogind support explicitly required, but elogind not found])
+        fi
+        AC_DEFINE(WITH_ELOGIND, 1, [elogind support])
+fi
+AC_SUBST(ELOGIND_CFLAGS)
+AC_SUBST(ELOGIND_LIBS, [-lelogind])
+
+dnl ---------------------------------------------------------------------------
 dnl UPower
 dnl ---------------------------------------------------------------------------
 
@@ -668,6 +704,7 @@ echo "
         systemd:                  ${use_systemd}
         ConsoleKit:               ${use_console_kit}
         UPower:                   ${use_upower}
+        elogind:                  ${use_elogind}
 
                     Features:
                     ---------

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -90,7 +90,8 @@ light_locker_SOURCES =	\
 light_locker_LDADD =		\
 	$(LIGHT_LOCKER_LIBS)	\
 	$(SAVER_LIBS)			\
-	$(SYSTEMD_LIBS)                 \
+	$(SYSTEMD_LIBS)		\
+	$(ELOGIND_LIBS)		\
 	$(NULL)
 
 light_locker_LDFLAGS = -export-dynamic

--- a/src/light-locker.c
+++ b/src/light-locker.c
@@ -144,7 +144,8 @@ main (int    argc,
                   "gtk:        %d\n"
                   "systemd:    %s\n"
                   "ConsoleKit: %s\n"
-                  "UPower:     %s",
+                  "UPower:     %s\n"
+                  "elogind:    %s",
                   GTK_MAJOR_VERSION,
 #ifdef WITH_SYSTEMD
                   "yes",
@@ -157,6 +158,11 @@ main (int    argc,
                   "no",
 #endif
 #ifdef WITH_UPOWER
+                  "yes"
+#else
+                  "no"
+#endif
+#ifdef WITH_ELOGIND
                   "yes"
 #else
                   "no"


### PR DESCRIPTION
This PR completes the work started by @dg98 in PR #109 . It adds the necessary preprocessor directives to make use of the --with-elogind autoconf option previously introduced, and explicitly links with the elogind library to provide full functionality.

These changes compile and run as expected (afik) on my gentoo machine with: lightdm-1.28.0, elogind-238.1, and openrc-0.38.2 which should resolve #103 .

This is my first go-round with autotools scripting, so any comments/critiques are most welcome.