### PR TITLE
Improve session id handling

### DIFF
--- a/src/gs-listener-dbus.c
+++ b/src/gs-listener-dbus.c
@@ -2195,6 +2195,11 @@ init_session_id (GSListener *listener)
 #ifdef WITH_SYSTEMD
         g_free (listener->priv->sd_session_id);
         listener->priv->sd_session_id = query_sd_session_id (listener);
+        if (listener->priv->sd_session_id == NULL)
+        {
+                gs_debug ("Falling back to XDG_SESSION_ID environment variable");
+                listener->priv->sd_session_id = g_strdup(getenv("XDG_SESSION_ID"));
+        }
         gs_debug ("Got sd-session-id: %s", listener->priv->sd_session_id);
 #endif
 }

--- a/src/gs-listener-dbus.c
+++ b/src/gs-listener-dbus.c
@@ -2190,7 +2190,10 @@ init_session_id (GSListener *listener)
 {
         g_free (listener->priv->session_id);
         listener->priv->session_id = query_session_id (listener);
-        gs_debug ("Got session-id: %s", listener->priv->session_id);
+        if (listener->priv->session_id == NULL)
+                g_error ("session_id is not set, is /proc mounted with hidepid>0?");
+        else
+                gs_debug ("Got session-id: %s", listener->priv->session_id);
 
 #ifdef WITH_SYSTEMD
         g_free (listener->priv->sd_session_id);


### PR DESCRIPTION
DBus calls don't like at all beeing called with an empty argument (it crashes the process). I've identified cases (for example when /proc is mounted with hidepid>0) where session_id and sd_session_id might end up empty.

The two patches here try to improve the situation by falling back to XDG_SESSION_ID (for sd_session_id) and printing an error when session_id is NULL.

Also it might make sense at one point to rename session_id by session_path or something, because it's not an ID. Also sd_session_id can be deduced from the session_path so the library calls to sd_pid_get_session might be dropped (they won't work with hidepid anyway).